### PR TITLE
Fixed a typo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         {
             "name": "Maxime Fabre",
             "email": "maxime@madewithlove.be",
-            "role": "Developper"
+            "role": "Developer"
         }
     ],
     "autoload": {


### PR DESCRIPTION
Changed `Developper` to `Developer`

![](http://i.giphy.com/1dcWGdOBg0wcU.gif)
